### PR TITLE
修复 #28 dev CI 无法正确保存 macOS 静态库

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,9 @@ jobs:
       - name: Generate build file
         run: |
           mkdir build
-          cmake -S ${{ matrix.cmake_root }} -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake -S ${{ matrix.cmake_root }}\
+                -B build -DCMAKE_BUILD_TYPE=$(echo ${BUILD_TYPE} | sed 's/.*/\u&/')\
+                -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache
       
       - name: Build Dandelion
         run: cmake --build build --parallel $(sysctl -n hw.activecpu)


### PR DESCRIPTION
之前 CI 脚本中 `-DCMAKE_BUILD_TYPE` 选项传参使用的是全小写 `release`，而在 macOS 下必须要是 `Release` 才能识别，否则就会应用默认 `Debug` 模式。该 pull request 在传参前把 `release` 第一个字母转换成大写，就能让 macOS 下 CMake 正确识别。