### PR TITLE
修复光栅化渲染管线中的线程同步问题

### DIFF
--- a/src/render/graphics_interface.h
+++ b/src/render/graphics_interface.h
@@ -213,11 +213,11 @@ struct Context
     static std::queue<FragmentShaderPayload> rasterizer_output_queue;
 
     /*! \~chinese 标识顶点着色器是否全部执行完毕。 */
-    static bool vertex_finish;
+    volatile static bool vertex_finish;
     /*! \~chinese 标识三角形是否全部被光栅化。 */
-    static bool rasterizer_finish;
+    volatile static bool rasterizer_finish;
     /*! \~chinese 标识片元着色器是否全部执行完毕。 */
-    static bool fragment_finish;
+    volatile static bool fragment_finish;
 
     /*! \~chinese 渲染使用的 frame buffer 。 */
     static FrameBuffer frame_buffer;


### PR DESCRIPTION
在 *src/render/graphics_interfaces.h* 中，`Context::vertex_finish` 等标志变量均应标记为 `volatile`。否则，实际执行时可能因多核缓存不一致而导致各流水段的线程不能按顺序结束，得到错误的渲染结果。

由于发布前的疏忽，相关代码没有从 dev channel 移植过来，目前已经 [有同学测试出了问题](https://xjtu.app/t/topic/13697)。