### PR TITLE
fix: change comparison function of EdgeRecord to ensure all edges are used when simplifying

### DIFF
--- a/src/geometry/meshedit.cpp
+++ b/src/geometry/meshedit.cpp
@@ -30,6 +30,10 @@ HalfedgeMesh::EdgeRecord::EdgeRecord(unordered_map<Vertex*, Matrix4f>& vertex_qu
 
 bool operator<(const HalfedgeMesh::EdgeRecord& a, const HalfedgeMesh::EdgeRecord& b)
 {
+    if (a.cost == b.cost) {
+        // Sort by edge id if cost are the same
+        return a.edge->id < b.edge->id;
+    }
     return a.cost < b.cost;
 }
 


### PR DESCRIPTION
fix #33 

原 issue 提供解决方法使用指针地址对比，这里使用的解决方法是比较边的 id，效果类似。

经测试，可以确保所有边都被加入队列（在 dev 仓库代码中测试）：

```
[Halfedge Mesh] [info] simplify object Cow (ID: 0)
[Halfedge Mesh] [info] original mesh: 2930 vertices, 5856 faces
[Halfedge Mesh] [info] start computing guadrics for each face
[Halfedge Mesh] [info] end computing quadrics for each face
[Halfedge Mesh] [info] start computing quadrics for each vertex
[Halfedge Mesh] [info] end computing quadrics for each vertex
[Halfedge Mesh] [info] start building edge records
[Halfedge Mesh] [debug] edge count: 8784; queue length: 8784
[Halfedge Mesh] [info] end building edge records
[Halfedge Mesh] [info] start collapsing edges
[Halfedge Mesh] [info] target number of faces: 1464
[Halfedge Mesh] [info] initial queue size: 8784
[Halfedge Mesh] [info] end collapsing edges, target reached
[Halfedge Mesh] [info] simplified mesh: 734 vertices, 1464 faces
[Halfedge Mesh] [info] simplification done
```