### PR TITLE
docs: revise scene subdirectory and update build.dox to include msys2-specific instructions

### DIFF
--- a/docs/build.dox
+++ b/docs/build.dox
@@ -39,7 +39,7 @@
 
 由于 Dandelion 首先是一个实验框架，用于西安交通大学计算机图形学课程教学，我们在 Dandelion 的公开频道上删去了所有实验题目的参考答案。然而物体拾取 (picking) 等功能依赖于射线求交，这部分代码被删去后会造成相当的不便。对此，我们的解决方案是将 *utils* 目录下的 *aabb.cpp*, *bvh.cpp* 和 *ray.cpp* 文件编译成两个静态库 *dandelion-ray* 和 *dandelion-bvh* ，只要在编译时链接它们就可以直接使用我们提供的实现。我们目前编译了这些版本的库：
 
-- Windows: Visual Studio 2022 / Clang / UCRT
+- Windows: Visual Studio 2022 / Clang / GCC
 - Linux: GCC 11 / Clang 14
 - macOS: AppleClang 14.0
 
@@ -57,7 +57,9 @@
   - 推荐使用 Visual Studio 2022、GNU GCC 12+、Clang 15+ ，可以使用最新的稳定版本。
 - CMake 3.14 及以上（推荐使用最新的稳定版本）
 
-在 Windows 平台上，从官方网站下载安装足够新的 Visual Studio 和 CMake 即可；在 Linux 平台上可以用包管理器安装编译器和 CMake；在 macOS 平台上，我们推荐安装 Xcode 命令行工具（不是 Xcode IDE），并使用 Homebrew 安装 CMake。
+在 Windows 平台上，我们推荐从官方网站下载安装足够新的 Visual Studio 和 CMake 即可，但若已有 mingw 或 MSYS2 平台构建软件的经验，也可借助 MSYS2 工具链使用移植版的 Clang 或 GCC 编译；在 Linux 平台上可以用包管理器安装编译器和 CMake；在 macOS 平台上，我们推荐安装 Xcode 命令行工具（不是 Xcode IDE），并使用 Homebrew 安装 CMake。
+
+> Windows MSYS2 平台需要的软件包为 `git toolchain cmake ninja`，其中 `git` 需要用 pacman 安装 cygwin 版本，而其余软件包则可用 `pacboy -S toolchain:p cmake:p ninja:p` 在对应环境安装。
 
 > 基于 Debian 的 Linux 发行版（使用 apt 包管理器）中，所需软件包名是 `build-essential cmake cmake-extras`，其他发行版请自行确定对应的包，亦可选择从源代码编译安装。
 
@@ -71,7 +73,7 @@
 
 \section compilation 编译
 
-由于日志输出是调试实验的重要参考，我们始终推荐从 **终端** 启动 Dandelion。在 Windows 平台上，我们推荐使用 PowerShell 而非 cmd，并推荐使用 Windows Terminal 作为终端模拟器；在 Linux 或 macOS 平台上可以直接使用默认的 shell 和终端模拟器，更熟悉这些工具的话也可以自己挑选。
+由于日志输出是调试实验的重要参考，我们始终推荐从 **终端** 启动 Dandelion。在 Windows 平台上使用 Visual Studio 编译时，我们推荐使用 PowerShell 而非 cmd，并推荐使用 Windows Terminal 作为终端模拟器；在 Windows 平台上使用 MSYS2 环境编译时，则应使用其附带终端；在 Linux 或 macOS 平台上可以直接使用默认的 shell 和终端模拟器，更熟悉这些工具的话也可以自己挑选。
 
 以下的所有说明中，均以“终端”代指终端模拟器而非 shell。不清楚二者区别的话，可以简单认为“终端”就是指能执行命令的窗口。
 
@@ -83,7 +85,7 @@
 - 如果是 Linux，安装了所需的额外依赖
 - 下载了 *dandelion-ray* 和 *dandelion-bvh* 两个静态库
 
-\subsection compilation-windows Windows
+\subsection compilation-windows-vs Windows (Visual Studio)
 
 由于 Dandelion 的源文件中包含 UTF-8 编码的中文，整个项目需要开启 `/utf-8` 选项编译，而 Windows 文件系统默认的中文编码是 GBK ，这可能导致兼容性问题（表现为“无访问权限”等）。因此，Dandelion 的源代码 **必须位于全英文路径下** 。
 
@@ -109,7 +111,11 @@
 > .\Release\dandelion.exe
 ```
 
-如果你希望在 Windows 平台上使用 MinGW 工具链构建，请注意 MinGW 是 Single-config 构建工具，执行命令的方式与 Linux 平台相同。
+\subsection compilation-windows-msys2 Windows (Clang / GCC)
+
+如果你希望在 Windows 平台上使用 MSYS2 移植版 Clang 或 GCC 构建项目，其执行命令的方式与 Linux 平台相同。注意区分 MSYS2 平台的不同环境，当前所支持的环境是 CLANG64 和 UCRT64。
+
+因为我们安装软件包时选择了 ninja 作为 make 的替代品，因此构建时如果需要手动调用 make，请换成 ninja。
 
 \subsection compilation-linux Linux
 

--- a/src/scene/camera.h
+++ b/src/scene/camera.h
@@ -6,6 +6,8 @@
 /*!
  * \ingroup rendering
  * \file scene/camera.h
+ * \~chinese
+ * \brief 包含相机的类，用来表示场景中的相机。
  */
 
 /*!

--- a/src/scene/group.h
+++ b/src/scene/group.h
@@ -10,11 +10,15 @@
 
 /*!
  * \ingroup rendering
+ * \ingroup simulation
  * \file scene/group.h
+ * \~chinese
+ * \brief 包含物体组的类。
  */
 
 /*!
  * \ingroup rendering
+ * \ingroup simulation
  * \~chinese
  * \brief 表示物体组的类。
  *
@@ -27,7 +31,11 @@ class Group
 {
 public:
 
-    /*! \~chinese 创建一个组只需要指定组名，加载模型数据要显式调用 `load` 方法。 */
+    /*!
+     * \~chinese
+     * 创建一个组只需要指定组名，加载模型数据要显式调用 `load` 方法。
+     * \param position 要创建组的组名
+     */
     Group(const std::string& group_name);
     ///@{
     /*! \~chinese 禁止复制组。 */
@@ -35,18 +43,22 @@ public:
     Group(const Group& other) = delete;
     ///@}
     ~Group() = default;
-    /*! \~chinese 被 `Scene::load` 调用，真正加载模型数据的函数。 */
+    /*!
+     * \~chinese
+     * 被 `Scene::load` 调用，真正加载模型数据的函数。
+     * \param file_path 要加载模型的文件路径
+     */
     bool load(const std::string& file_path);
     /*! \~chinese 组中所有的物体。 */
     std::vector<std::unique_ptr<Object>> objects;
-    /*! \~chinese 组的唯一 ID 。 */
+    /*! \~chinese 组的唯一 ID。 */
     std::size_t id;
     /*! \~chinese 组名，来自加载时的文件名。 */
     std::string name;
 
 private:
 
-    /*! \~chinese 下一个可用的组 ID 。 */
+    /*! \~chinese 下一个可用的组 ID。 */
     static std::size_t              next_available_id;
     std::shared_ptr<spdlog::logger> logger;
 };

--- a/src/scene/light.h
+++ b/src/scene/light.h
@@ -6,17 +6,25 @@
 /*!
  * \ingroup rendering
  * \file scene/light.h
+ * \~chinese
+ * \brief 包含光源的类，目前只有一个点光源。
  */
 
 /*!
  * \ingroup rendering
  * \~chinese
- * \brief 一个点光源。
+ * \brief 表示一个点光源的类。
  */
 struct Light
 {
     /*! \~chinese 禁止无参构造。 */
     Light() = delete;
+    /*!
+     * \~chinese
+     * 在指定位置创建一个指定强度的点光源。
+     * \param position 光源位置
+     * \param position 光源强度
+     */
     Light(const Eigen::Vector3f& position, float intensity);
 
     /*! \~chinese 光源位置。 */

--- a/src/scene/object.h
+++ b/src/scene/object.h
@@ -21,6 +21,8 @@
  * \file scene/object.h
  * \ingroup rendering
  * \ingroup simulation
+ * \~chinese
+ * \brief 包含物体的类。
  */
 
 /*!
@@ -40,6 +42,15 @@ class Object
 {
 public:
 
+    /*!
+     * \~chinese
+     * \brief 创建一个物体
+     *
+     * 物体刚创建时 mesh 中没有数据，需要创建之后再添加。mesh 数据的加载过程是在
+     * `Group::load` 中完成的
+     *
+     * \param object_name 物体名字
+     */
     Object(const std::string& object_name);
     ///@{
     /*! \~chinese 禁止复制物体。 */
@@ -133,6 +144,12 @@ public:
 
 private:
 
+    /*!
+     * \~chinese
+     * \brief 将新的 BVH 线框添加到 `BVH_boxes` 中
+     *
+     * \param node 初始 BVH 结点，函数会递归更新子结点，将所有 BVH 包围盒都添加为线框
+     */
     void refresh_BVH_boxes(BVHNode* node);
     /*! \~chinese 下一个可用的物体 ID 。 */
     static std::size_t next_available_id;

--- a/src/scene/scene.h
+++ b/src/scene/scene.h
@@ -21,13 +21,16 @@
 /*!
  * \file scene/scene.h
  * \ingroup rendering
+ * \ingroup simulation
+ * \~chinese
+ * \brief 包含场景的类。
  */
 
 /*!
  * \ingroup rendering
  * \ingroup simulation
  * \~chinese
- * \brief 表示一个包含相机、光源、物体的完整场景。
+ * \brief 表示一个包含相机、光源、物体等对象的完整场景。
  *
  * `Scene` 是一个对象语义的类，它既包含完成图形设计和渲染所需的全部数据，
  * 也具有渲染自身预览效果的功能。当前的设计是：控制器 (Controller) 在 OpenGL
@@ -60,6 +63,8 @@ public:
      * \brief 从指定路径加载模型文件到这个场景中。
      *
      * 这个函数只会根据文件名创建一个物体组，然后调用物体组的 `load` 方法加载文件。
+     *
+     * \param file_path 要加载的模型文件路径
      */
     bool load(const std::string& file_path);
     /*! \~chinese 备份物体当前状态并开始模拟，此后每一帧都会调用所有物体的 `update` 方法。 */
@@ -73,8 +78,12 @@ public:
     /*! \~chinese
      * \brief 绘制整个场景。
      *
-     * `render` 方法是场景对外的绘制接口，不会直接绘制任何内容，只负责调用每个 Object 的 `render`
+     * `render` 方法是场景对外的绘制接口，不会直接绘制任何内容，只负责调用每个 `Object` 的 `render`
      * 方法、`render_camera` 和 `render_lights` 方法。
+     *
+     * \param shader `Shader` 对象的引用，会传给待渲染的每个物体
+     * \param mode 当前工作模式，根据模式的不同，会选择性渲染某些元素。
+     * 例如只有建模模式下，才会渲染半边网格
      */
     void render(const Shader& shader, WorkingMode mode);
 
@@ -101,6 +110,8 @@ private:
      *
      * 这个函数在 \f$x\f$ 和 \f$z\f$ 方向各绘制 1000 条网格线，并分别用红、绿、蓝三色绘制
      * \f$x,y,z\f$ 三轴正半轴。
+     *
+     * \param shader `Shader` 对象的引用
      */
     static void render_ground(const Shader& shader);
     /*! \~chinese
@@ -109,12 +120,16 @@ private:
      * 根据场景对象的相机参数（位置、目标点、远近平面、视角），绘制四棱锥形的相机视锥。
      * 由于近平面通常离相机视点很近，这个函数不会绘制近平面。离线渲染时，
      * 会裁剪掉视锥范围外的所有内容。
+     *
+     * \param shader `Shader` 对象的引用
      */
     void render_camera(const Shader& shader);
     /*! \~chinese
      * \brief 在渲染模式下绘制光源。
      *
-     * 这个函数将场景中每个点光源绘制成六个亮点。
+     * 这个函数将一个点光源表示成一个中心点和六个亮点。
+     *
+     * \param shader `Shader` 对象的引用
      */
     void render_lights(const Shader& shader);
     /*!


### PR DESCRIPTION
- 检查了 `scene` 目录下注释文档与代码不符之处，补全了文件概览介绍和函数参数。
- 在 `build.dox` 一章中添加了更清楚的 Windows MSYS2 平台构建指南